### PR TITLE
Make mobile images edge to edge

### DIFF
--- a/src/components/image-dialog.tsx
+++ b/src/components/image-dialog.tsx
@@ -54,16 +54,11 @@ export default function ImageDialog({
       }}
     >
       <div
-        className="relative flex items-center justify-center"
-        style={{
-          width: 'calc(100vw - 128px)',
-          height: 'calc(100vh - 128px)',
-          margin: '64px',
-        }}
+        className="relative flex h-full w-full items-center justify-center md:h-[calc(100vh-128px)] md:w-[calc(100vw-128px)] md:m-16"
       >
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black bg-opacity-50 text-white hover:bg-opacity-75"
+          className="absolute top-4 right-4 z-10 flex h-8 w-8 items-center justify-center rounded-full bg-black bg-opacity-50 text-white hover:bg-opacity-75 md:top-4 md:right-4"
         >
           ×
         </button>

--- a/src/components/post-detail.tsx
+++ b/src/components/post-detail.tsx
@@ -86,10 +86,10 @@ export default function PostDetail({ post, onLike }: PostDetailProps) {
   if (images.length === 0) return null
 
   return (
-    <div className="mx-auto flex max-w-6xl flex-col overflow-hidden rounded-lg border border-gray-300 bg-white shadow-lg md:h-[80vh] md:flex-row">
+    <div className="mx-auto flex h-full w-full max-w-6xl flex-col overflow-hidden bg-white md:h-[80vh] md:flex-row md:rounded-lg md:border md:border-gray-300 md:shadow-lg">
       {/* Image carousel */}
-      <div className="flex flex-1 items-center justify-center bg-white">
-        <div className={cn('group relative max-h-full max-w-full')}>
+      <div className="flex w-full flex-1 items-center justify-center bg-white">
+        <div className={cn('group relative h-full w-full max-h-full max-w-full')}>
           <Carousel
             setApi={setApi}
             className="h-full max-h-full w-full max-w-full"
@@ -109,8 +109,7 @@ export default function PostDetail({ post, onLike }: PostDetailProps) {
                       <img
                         src={image.cdnUrl}
                         alt={image.altText || `Post image ${index + 1}`}
-                        className="max-h-full max-w-full object-contain object-center"
-                        style={{ width: 'auto', height: 'auto' }}
+                        className="max-h-full w-full object-contain object-center md:max-w-full md:w-auto"
                       />
                     ) : (
                       <VideoPlayer image={image} index={index} />
@@ -318,8 +317,7 @@ function VideoPlayer({ image, index }: { image: any; index: number }) {
         metadata={{
           video_title: image.altText || `Post video ${index + 1}`,
         }}
-        className="max-h-full max-w-full object-contain"
-        style={{ width: 'auto', height: 'auto' }}
+        className="max-h-full w-full object-contain md:max-w-full md:w-auto"
         autoPlay={false}
       />
     )
@@ -328,11 +326,10 @@ function VideoPlayer({ image, index }: { image: any; index: number }) {
   return (
     <video
       src={image.cdnUrl}
-      className="max-h-full max-w-full object-contain"
+      className="max-h-full w-full object-contain md:max-w-full md:w-auto"
       controls
       preload="metadata"
       aria-label={image.altText || `Post video ${index + 1}`}
-      style={{ width: 'auto', height: 'auto' }}
     />
   )
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Make image dialog edge-to-edge on mobile to remove excessive padding.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->

---

[Open in Web](https://cursor.com/agents?id=bc-470843b9-e555-4c3e-b8db-6f31804abf2b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-470843b9-e555-4c3e-b8db-6f31804abf2b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)